### PR TITLE
[publish.py] Fix syntax error for closed bracket && Replace time.sleep by rospy.sleep

### DIFF
--- a/scripts/publish.py
+++ b/scripts/publish.py
@@ -6,13 +6,13 @@ from forcegaugepublisher import ForceGaugePublisher
 import time
 import sys
 
-if __name__=="__main__":
-    if len( sys.argv ) < 2:
-        print("publish force data read from imada forcegauge"
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("publish force data read from imada forcegauge")
         print("usage:program <serial port> <output topic (optional, default:ForceGauge)>")
         sys.exit(0)
 
-    if len ( sys.argv ) > 2:
+    if len(sys.argv) > 2:
         topicname = sys.argv[2]
     else:
         topicname = "ForceGauge"
@@ -20,9 +20,10 @@ if __name__=="__main__":
     a = ForceGaugePublisher(topicname, sys.argv[1])
 
     try:
-        while True:
+        r = rospy.Rate(100)  # 100Hz
+        while not rospy.is_shutdown():
             a.publish()
-            time.sleep(0.1)
+            r.sleep()
 
     except KeyboardInterrupt:
         del a


### PR DESCRIPTION
* まず、publish.pyがprint文のカッコウを閉じてないため、直しました。
* time.sleepはpublish時間を考慮してないため、rospy.sleepに変更しました。
* 変更前： time.sleep(0.1)だと
```
$ rostopic hz /ForceGauge 
subscribed to [/ForceGauge]
average rate: 9.321
	min: 0.107s max: 0.108s std dev: 0.00052s window: 9
average rate: 9.320
	min: 0.107s max: 0.108s std dev: 0.00046s window: 18
average rate: 9.318
	min: 0.107s max: 0.108s std dev: 0.00045s window: 27
average rate: 9.315
	min: 0.107s max: 0.108s std dev: 0.00045s window: 37
```
* 変更前： time.sleep(0.01)だと
```
$ rostopic hz /ForceGauge 
subscribed to [/ForceGauge]
average rate: 57.987
	min: 0.017s max: 0.018s std dev: 0.00043s window: 57
average rate: 58.405
	min: 0.017s max: 0.018s std dev: 0.00033s window: 116
average rate: 58.521
	min: 0.017s max: 0.018s std dev: 0.00029s window: 175
average rate: 58.383
	min: 0.017s max: 0.018s std dev: 0.00034s window: 233
average rate: 58.349
	min: 0.017s max: 0.018s std dev: 0.00035s window: 29
```
* 変更後：
```
$ rostopic hz /ForceGauge 
subscribed to [/ForceGauge]
average rate: 99.941
	min: 0.009s max: 0.012s std dev: 0.00034s window: 99
average rate: 99.957
	min: 0.009s max: 0.012s std dev: 0.00025s window: 199
average rate: 99.989
	min: 0.009s max: 0.012s std dev: 0.00026s window: 299
average rate: 99.985
	min: 0.009s max: 0.012s std dev: 0.00027s window: 399
average rate: 100.000
	min: 0.009s max: 0.012s std dev: 0.00025s window: 500
average rate: 99.996
	min: 0.009s max: 0.012s std dev: 0.00024s window: 600
average rate: 99.990
	min: 0.009s max: 0.012s std dev: 0.00024s window: 700
average rate: 100.000
	min: 0.009s max: 0.012s std dev: 0.00023s window: 800
```
